### PR TITLE
i686-elf-grub 2.06 (new formula)

### DIFF
--- a/Formula/i/i686-elf-grub.rb
+++ b/Formula/i/i686-elf-grub.rb
@@ -1,0 +1,56 @@
+class I686ElfGrub < Formula
+  desc "GNU GRUB bootloader for i686-elf"
+  homepage "https://savannah.gnu.org/projects/grub"
+  url "https://ftp.gnu.org/gnu/grub/grub-2.06.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.06.tar.xz"
+  sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
+  license "GPL-3.0-or-later"
+
+  depends_on "help2man" => :build
+  depends_on "i686-elf-binutils" => :build
+  depends_on "i686-elf-gcc" => [:build, :test]
+  depends_on "objconv" => :build
+  depends_on "texinfo" => :build
+  depends_on "gettext"
+  depends_on "xorriso"
+  depends_on "xz"
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "python" => :build
+
+  def install
+    target = "i686-elf"
+    ENV["CFLAGS"] = "-Os -Wno-error=incompatible-pointer-types"
+
+    mkdir "build" do
+      args = %W[
+        --disable-werror
+        --target=#{target}
+        --prefix=#{prefix}/#{target}
+        --bindir=#{bin}
+        --libdir=#{lib}/#{target}
+        --with-platform=pc
+        --program-prefix=#{target}-
+      ]
+
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    target = "i686-elf"
+    (testpath/"boot.c").write <<~C
+      __asm__(
+        ".align 4\\n"
+        ".long 0x1BADB002\\n"
+        ".long 0x0\\n"
+        ".long -(0x1BADB002 + 0x0)\\n"
+      );
+    C
+    system Formula["#{target}-gcc"].bin/"#{target}-gcc", "-c", "-o", "boot", "boot.c"
+    assert_match "0",
+      shell_output("#{bin}/#{target}-grub-file --is-x86-multiboot boot; echo -n $?")
+  end
+end

--- a/Formula/i/i686-elf-grub.rb
+++ b/Formula/i/i686-elf-grub.rb
@@ -6,6 +6,15 @@ class I686ElfGrub < Formula
   sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 arm64_sequoia: "5e69ba0912b4af63d9096b700661f94d7eee58f29cc6918a9bddbd1464ba6ab4"
+    sha256 arm64_sonoma:  "589a6326426f6af516b6f4e9c5de899d0e04e65da8e6818be289c0773b79f727"
+    sha256 arm64_ventura: "6019c03071dfb8b6317748ab2179c9db42f0a5fb5bc99e6beceb2f6f45c0a3a2"
+    sha256 sonoma:        "3016d288f6ea2fd6493e4217ce393b063615b95581fc4cd1c24579f8801bb019"
+    sha256 ventura:       "92b92f9ff2d8fdb59fe50b96556d481d3d247639e0354cf03eac74abf2827f6f"
+    sha256 x86_64_linux:  "6b00321d73386ac1e2c3a338fd6ea69b509bf0bd1bf6ea2025ff0a7740fc983a"
+  end
+
   depends_on "help2man" => :build
   depends_on "i686-elf-binutils" => :build
   depends_on "i686-elf-gcc" => [:build, :test]

--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -1,0 +1,77 @@
+class X8664ElfGrub < Formula
+  desc "GNU GRUB bootloader for x86_64-elf"
+  homepage "https://savannah.gnu.org/projects/grub"
+  url "https://ftp.gnu.org/gnu/grub/grub-2.06.tar.xz"
+  mirror "https://mirrors.ocf.berkeley.edu/gnu/grub/grub-2.06.tar.xz"
+  sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
+  license "GPL-3.0-or-later"
+
+  depends_on "help2man" => :build
+  depends_on "objconv" => :build
+  depends_on "pkgconf" => :build
+  depends_on "texinfo" => :build
+  depends_on "x86_64-elf-binutils" => :build
+  depends_on "x86_64-elf-gcc" => [:build, :test]
+  depends_on "freetype"
+  depends_on "gettext"
+  depends_on "mtools"
+  depends_on "xorriso"
+  depends_on "xz"
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "python" => :build
+
+  resource "unifont" do
+    url "https://ftp.gnu.org/gnu/unifont/unifont-16.0.02/unifont-16.0.02.pcf.gz", using: :nounzip
+    mirror "https://mirrors.ocf.berkeley.edu/gnu/unifont/unifont-16.0.02/unifont-16.0.02.pcf.gz"
+    sha256 "02a3fe11994d3cdaf1d4bd5d2b6b609735e6823e01764ae83b704e02ec2f640d"
+  end
+
+  def install
+    target = "x86_64-elf"
+    ENV["CFLAGS"] = "-Os -Wno-error=incompatible-pointer-types"
+
+    resource("unifont").stage do
+      cp "unifont-16.0.02.pcf.gz", buildpath/"unifont.pcf.gz"
+    end
+    ENV["UNIFONT"] = buildpath/"unifont.pcf.gz"
+
+    mkdir "build" do
+      args = %W[
+        --disable-werror
+        --enable-grub-mkfont
+        --target=#{target}
+        --prefix=#{prefix}/#{target}
+        --bindir=#{bin}
+        --libdir=#{lib}/#{target}
+        --with-platform=efi
+        --program-prefix=#{target}-
+      ]
+
+      system "../configure", *args
+      system "make"
+      system "make", "install"
+
+      mkdir_p "#{prefix}/#{target}/share/grub"
+
+      system "./grub-mkfont",
+        "--output=#{prefix}/#{target}/share/grub/unicode.pf2",
+        ENV["UNIFONT"].to_s
+    end
+  end
+
+  test do
+    target = "x86_64-elf"
+    (testpath/"boot.c").write <<~C
+      __asm__(
+        ".align 4\\n"
+        ".long 0x1BADB002\\n"
+        ".long 0x0\\n"
+        ".long -(0x1BADB002 + 0x0)\\n"
+      );
+    C
+    system Formula["#{target}-gcc"].bin/"#{target}-gcc", "-c", "-o", "boot", "boot.c"
+    assert_match "0",
+      shell_output("#{bin}/#{target}-grub-file --is-x86-multiboot boot; echo -n $?")
+  end
+end

--- a/Formula/x/x86_64-elf-grub.rb
+++ b/Formula/x/x86_64-elf-grub.rb
@@ -6,6 +6,15 @@ class X8664ElfGrub < Formula
   sha256 "b79ea44af91b93d17cd3fe80bdae6ed43770678a9a5ae192ccea803ebb657ee1"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 arm64_sequoia: "b76374ca36987f1bfef95216c14af606d263e17863df4d7b1a33b3cf65d953a3"
+    sha256 arm64_sonoma:  "b5687ab4349a959b3bae9afb76103ab55bb5f0902eb199ab4aba00d974fc6c49"
+    sha256 arm64_ventura: "406969f44c862754472dac117737965cf4c1ba427eba3ff478f0ce0bbfa75cc7"
+    sha256 sonoma:        "a9e8fd25bd063a89080bee2e33d88e70fcd0227a2a8fb20e43e270d59062da95"
+    sha256 ventura:       "e1770bd69fae7db684989eee7416337abb4f301a53a1034ab39efee73547cda9"
+    sha256 x86_64_linux:  "c578c06b175f785718eafaa9e54c45bd767ba73a041cf1db73a72a6103573375"
+  end
+
   depends_on "help2man" => :build
   depends_on "objconv" => :build
   depends_on "pkgconf" => :build

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -6,5 +6,6 @@
   "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/xip_ram_perms.elf",
-  "qemu": "share/qemu/*"
+  "qemu": "share/qemu/*",
+  "x86_64-elf-grub": "lib/x86_64-elf/grub/i386-pc/*"
 }

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -3,6 +3,7 @@
   "aws-sam-cli": "libexec/lib/python*/site-packages/samcli/local/rapid/aws-lambda-rie-*",
   "balena-cli": "**/*",
   "faust": "share/faust/android/app/lib/libsndfile/lib/*/libsndfile.so",
+  "i686-elf-grub": "lib/i686-elf/grub/i386-pc/*",
   "lima": "share/lima/lima-guestagent.Linux-*",
   "picotool": "share/picotool/xip_ram_perms.elf",
   "qemu": "share/qemu/*"


### PR DESCRIPTION
Add GNU GRUB bootloader cross-compiler for i686-elf target. This formula builds GRUB bootloader components specifically for i386/i686 architecture, which is essential for OS development and bootloader customization.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
